### PR TITLE
Fixed getting test package name with svn 1.7

### DIFF
--- a/bin/rhts-mk-diff-since-last-tag
+++ b/bin/rhts-mk-diff-since-last-tag
@@ -34,7 +34,7 @@ if [ -d "CVS" ]; then
     cvs diff -r $CURRENT_TAG
 fi
 
-if [ -d ".svn" ]; then
+if svn info &> /dev/null; then
     echo "SVN not supported yet!"
     exit 1
 fi

--- a/bin/rhts-mk-get-current-tag
+++ b/bin/rhts-mk-get-current-tag
@@ -39,7 +39,7 @@ if [ -d "CVS" ]; then
 fi
 
 # for svn, just use the svn repo revision number for the package revision number
-if [ -d ".svn" ]; then
+if svn info &> /dev/null; then
 	CURRENT_REVISION=`svn info | fgrep "Revision:" | awk '{print $2}'`
 	CURRENT_TAG="$PACKAGE_NAME-$CURRENT_VERSION-$CURRENT_REVISION"
 fi

--- a/bin/rhts-mk-get-test-package-name
+++ b/bin/rhts-mk-get-test-package-name
@@ -45,7 +45,7 @@ if [ -d $SOURCE_DIR/CVS ]; then
 	PACKAGE_NAME="$REPO_NAME-$REPO_PATH"
 fi
 
-if [ -d "$SOURCE_DIR/.svn" ]; then
+if svn info &> /dev/null; then
 	REPO_ROOT=`svn info $SOURCE_DIR | fgrep "Repository Root:" | awk '{print $3}'`
 	REPO_NAME=`echo $REPO_ROOT | sed -e "s'svn+ssh://[^@]*@''" | sed -e "s/http[s]\?:\/\///" | sed -e "s/[\.\/]/-/g"`
 	PACKAGE_NAME=`svn info $SOURCE_DIR  |  fgrep "URL:" | awk '{print $2}' | sed -e "s'svn+ssh://[^@]*@''" | sed -e "s/http[s]\?:\/\///" | sed -e "s/[\.\/]/-/g"`


### PR DESCRIPTION
Svn 1.7 doesn't have .svn in every subdirectory of the working copy. Instead it has .svn in working copy root only - same as git. 

That's why detecting svn repo when generating test package name doesn't work.

To make it work I'm using same approach as the one used to detect git repo.
