### PR TITLE
ci: add check for Fedora 32

### DIFF
--- a/.github/workflows/rpm-build.yml
+++ b/.github/workflows/rpm-build.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       max-parallel: 4
       matrix:
-        fedora-version: [29, 30, 31, rawhide]
+        fedora-version: [30, 31, 32, rawhide]
     container:
       image: fedora:${{ matrix.fedora-version }}
     steps:


### PR DESCRIPTION
Fedora 32 branched. Let's add it.

Change-Id: Ib71406f811807cae6d06aee3f30afe0f00f226b5
Signed-off-by: Martin Styk <mastyk@redhat.com>